### PR TITLE
updated import to explicitly include firestore

### DIFF
--- a/frontend/components/auth/Register.js
+++ b/frontend/components/auth/Register.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { View, Button, TextInput } from 'react-native'
 
 import firebase from 'firebase'
+import "firebase/firestore";
 
 export class Register extends Component {
     constructor(props) {


### PR DESCRIPTION
I was getting an error firebase.firestore() is not a function when running without redux as part of your tutorial around the 1hr timestamp. nothing was getting written to Firestore. had to explicitly include firestore as per the answer here. https://stackoverflow.com/questions/46636255/firebase-firestore-is-not-a-function-when-trying-to-initialize-cloud-firestore?noredirect=1&lq=1. This is because firebase core does not include the firestore library.